### PR TITLE
Support for building for iOS extension

### DIFF
--- a/RSKPlaceholderTextView.podspec
+++ b/RSKPlaceholderTextView.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.license      = { :type => 'Apache', :file => 'LICENSE' }
   s.authors      = { 'Ruslan Skorb' => 'ruslan.skorb@gmail.com' }
   s.source       = { :git => 'https://github.com/ruslanskorb/RSKPlaceholderTextView.git', :tag => s.version.to_s }
-  s.platform     = :ios, '8.0'
+  s.platform     = :ios, '9.0'
   s.source_files = 'RSKPlaceholderTextView/*.{swift}'
   s.framework    = 'UIKit'
   s.requires_arc = true

--- a/RSKPlaceholderTextView.xcodeproj/project.pbxproj
+++ b/RSKPlaceholderTextView.xcodeproj/project.pbxproj
@@ -98,7 +98,7 @@
 				TargetAttributes = {
 					B84FF8511C1E902200DCC2A6 = {
 						CreatedOnToolsVersion = 7.2;
-						LastSwiftMigration = "1000";
+						LastSwiftMigration = 1000;
 					};
 				};
 			};
@@ -186,7 +186,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -236,7 +236,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
@@ -250,6 +250,7 @@
 		B84FF85B1C1E902200DCC2A6 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
@@ -270,6 +271,7 @@
 		B84FF85C1C1E902200DCC2A6 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;

--- a/RSKPlaceholderTextView/RSKPlaceholderTextView.swift
+++ b/RSKPlaceholderTextView/RSKPlaceholderTextView.swift
@@ -201,13 +201,9 @@ import UIKit
             
             userInterfaceLayoutDirection = self.effectiveUserInterfaceLayoutDirection
         }
-        else if #available(iOS 9.0, *) {
-            
-            userInterfaceLayoutDirection = UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute)
-        }
         else {
             
-            userInterfaceLayoutDirection = UIApplication.shared.userInterfaceLayoutDirection
+            userInterfaceLayoutDirection = UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute)
         }
         
         switch userInterfaceLayoutDirection {


### PR DESCRIPTION
Hi, right now this project can't be used in iOS extensions (like a share extension with user inputs) because of a fallback for iOS 8.0.

If we remove that fallback and build for iOS 9.0 as the base deployment target, this project will work with iOS extensions just fine. I wasn't able to utilize [availability conditions](https://docs.swift.org/swift-book/ReferenceManual/Statements.html#ID522) because the iOSApplicationExtension condition is a subset of iOS condition.

If this is something you'd like to add to the project, it'd be great! If not, just reject the pull request and I'll use my fork of your project.

